### PR TITLE
Support for keypresses in Maui

### DIFF
--- a/Microsoft.Maui.WebDriver.Host/MauiDriver.cs
+++ b/Microsoft.Maui.WebDriver.Host/MauiDriver.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Maui.Essentials;
 
 namespace Microsoft.Maui.WebDriver.Host
 {
@@ -16,7 +17,7 @@ namespace Microsoft.Maui.WebDriver.Host
 #if ANDROID
 			MauiApplication.Current.Application.Windows;
 
-#elif IOS
+#elif IOS || __MACCATALYST__
 			MauiUIApplicationDelegate.Current.Application.Windows;
 #else
 			new IWindow[0];
@@ -25,6 +26,13 @@ namespace Microsoft.Maui.WebDriver.Host
 				return windows.Select(window => new MauiElement(window.Content));
 			}
 		}
+
+		internal static T InvokeOnMainThread<T> (Func<T> func)
+        {
+			T t = default(T);
+			MainThread.BeginInvokeOnMainThread(() => t = func());
+			return t;
+        }
 	}
 }
 

--- a/Microsoft.Maui.WebDriver.Host/MauiElement.cs
+++ b/Microsoft.Maui.WebDriver.Host/MauiElement.cs
@@ -124,24 +124,25 @@ namespace Microsoft.Maui.WebDriver.Host
 		public ReadOnlyCollection<IWebElement> FindElements(By by)
 			=> by.FindElements(this);
 
-		bool SetViaProperty<T> (IView view, string propertyName, T newValue)
-        {
+		bool SetViaProperty<T>(IView view, string propertyName, T newValue)
+		{
 			// look for a public property named propertyName with type T and with a getter.
 			var prop = view.GetType().GetProperty(propertyName, typeof(T));
 			if (prop == null || (prop.SetMethod == null || !prop.SetMethod.IsPublic))
 				return false;
 			try
-            {
+			{
 				prop.SetValue(view, newValue);
-            } catch
-            {
+			}
+			catch
+			{
 				return false;
-            }
+			}
 			return true;
-        }
+		}
 
-		T GetViaProperty<T> (IView view, string propertyName)
-        {
+		T GetViaProperty<T>(IView view, string propertyName)
+		{
 			// look for a public property named propertyName with type T and with a getter.
 			var prop = view.GetType().GetProperty(propertyName, typeof(T));
 			if (prop == null || (prop.GetMethod == null || !prop.GetMethod.IsPublic))

--- a/Microsoft.Maui.WebDriver.Host/PlatformDriverBase.cs
+++ b/Microsoft.Maui.WebDriver.Host/PlatformDriverBase.cs
@@ -1,6 +1,7 @@
 ﻿using OpenQA.Selenium;
 using OpenQA.Selenium.Internal;
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Drawing;
@@ -157,5 +158,16 @@ namespace Microsoft.Maui.WebDriver.Host
 		{
 			get;
 		}
+#if DEBUG
+		internal static StreamWriter DebugOut;
+		internal static void DebugWriteLine(string message)
+		{
+			if (DebugOut != null)
+			{
+				DebugOut.WriteLine(message);
+				DebugOut.Flush();
+			}
+		}
+#endif
 	}
 }


### PR DESCRIPTION
Added a flavor of `InvokeOnMainThread<T>`
Made text entry thread safe
Added a debug output vector (useful for Mac catalyst which has no console output that I could find)
Changed `IO` conditional compilation to also have `__MACCATALYST__` (didn't see a `MACCATALYST` switch).
